### PR TITLE
SDO: do not exit on error

### DIFF
--- a/sdo/download.go
+++ b/sdo/download.go
@@ -65,7 +65,8 @@ func (download Download) Do(bus *can.Bus) error {
 	req := canopen.NewRequest(frame, uint32(download.ResponseCobID))
 	resp, err := c.Do(req)
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return err
 	}
 
 	frame = resp.Frame

--- a/sdo/upload.go
+++ b/sdo/upload.go
@@ -43,7 +43,8 @@ func (upload Upload) Do(bus *can.Bus) ([]byte, error) {
 	req := canopen.NewRequest(frame, uint32(upload.ResponseCobID))
 	resp, err := c.Do(req)
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
+		return nil, err
 	}
 
 	frame = resp.Frame


### PR DESCRIPTION
do not call log.Fatal() on SDO request errors like timeout

fixes #1