### PR TITLE
Handle speed issue with Do().

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,8 +1,9 @@
 package canopen
 
 import (
-	"github.com/brutella/can"
 	"time"
+
+	"github.com/brutella/can"
 )
 
 // A Client handles message communication by sending a request
@@ -15,11 +16,13 @@ type Client struct {
 // Do sends a request and waits for a response.
 // If the response frame doesn't arrive on time, an error is returned.
 func (c *Client) Do(req *Request) (*Response, error) {
+	rch := can.Wait(c.Bus, req.ResponseID, c.Timeout)
+
 	if err := c.Bus.Publish(req.Frame.CANFrame()); err != nil {
 		return nil, err
 	}
 
-	resp := <-can.Wait(c.Bus, req.ResponseID, c.Timeout)
+	resp := <-rch
 
 	return &Response{CANopenFrame(resp.Frame), req}, resp.Err
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/brutella/canopen
 
+go 1.15
+
 require github.com/brutella/can v0.0.1


### PR DESCRIPTION
This resolved an issue I had with a low latency setup in which an SDO response would be received before the handler (waiter) was registered on the response id -- causing a timeout error.  