### PR TITLE
Send full 8 byte of SDO message or full 4 byte of data 

### DIFF
--- a/sdo/download.go
+++ b/sdo/download.go
@@ -56,6 +56,11 @@ func (download Download) Do(bus *can.Bus) error {
 		download.ObjectIndex.SubIndex,
 	}
 
+	// CiA301 Standard expects all bytes to be sent
+	for len(data) < 4 {
+		data = append(data, 0x0)
+	}
+
 	// Initiate
 	frame := canopen.Frame{
 		CobID: download.RequestCobID,


### PR DESCRIPTION
In comparison to PDO's CiA301 standard expects 8 byte of the SDO message. 
Some devices would abort communication, if not full length of message was sent.

Thanks again for doing this repo